### PR TITLE
[Feature] キャレットモード(モドキ)の追加

### DIFF
--- a/coffee/command.coffee
+++ b/coffee/command.coffee
@@ -86,6 +86,7 @@ class g.CommandExecuter
         GoFMode               : triggerInsideContent
         GoExtFMode            : triggerInsideContent
         GoEmergencyMode       : triggerInsideContent
+        GoCaretMode           : triggerInsideContent
         FocusOnFirstInput     : triggerInsideContent
         BackToPageMark        : triggerInsideContent
         RestoreTab            : sendToBackground

--- a/coffee/model.coffee
+++ b/coffee/model.coffee
@@ -149,12 +149,17 @@ g.model =
         g.logger.d "enterFMode"
         @changeMode( (new g.ExtFMode).setOption( opt || {} ) )
 
+    enterCaretMode : (target) ->
+        g.logger.d "enterCaretMode"
+        @changeMode( (new g.CaretMode).setTarget( target ) )
+
     isInNormalMode    : -> @curMode.getName() == "NormalMode"
     isInInsertMode    : -> @curMode.getName() == "InsertMode"
     isInSearchMode    : -> @curMode.getName() == "SearchMode"
     isInCommandMode   : -> @curMode.getName() == "CommandMode"
     isInFMode         : -> @curMode.getName() == "FMode"
     isInEmergencyMode : -> @curMode.getName() == "EmergencyMode"
+    isInCaretMode     : -> @curMode.getName() == "CaretMode"
 
     goNextSearchResult : (reverse) ->
         unless @searcher? then return
@@ -254,7 +259,7 @@ g.model =
             when "aliases" then @getAlias = getAliasFirst
 
     onFocus : (target) ->
-        if @isInCommandMode() or @isInSearchMode() or @isInEmergencyMode()
+        if @isInCommandMode() or @isInSearchMode() or @isInEmergencyMode() or @isInCaretMode()
             g.logger.d "onFocus:nothing should be done in the cur mode"
             return
 


### PR DESCRIPTION
キャレットモード(モドキ)と、
キャレットヒントモードを追加しました。
**モドキの理由は補足にて後述します。**
# 機能概要
1. キャレットモード(モドキ)
   キャレットを表示し、操作できるモードです。
   キーバインドは、キャレットなので imap 依存にしています。
2. キャレットヒントモード
   caret-hint.js のようにヒントの箇所にキャレットを移動するモードです。
# 使い方

ExtFMode から、`c` 押下でキャレットヒントモードに遷移できます。
コマンド `:GoExtFMode --caret` でも遷移可能です。
ヒント選択後に、キャレットモード(モドキ)へ遷移します。
`Escape` でキャレットモードが終了します。

コマンド `:GoCaretMode` でも一応キャレットモード(モドキ)に遷移できます。
この場合、ドキュメントの先頭にキャレットが表示されます。
# 補足
1. モドキの理由
   `document.body.contentEditable` を `true` にして、ドキュメント全体を編集可能にすることで
   キャレットを無理矢理表示させているためです。
   **ドキュメントが編集できてしまうという問題があります。**
   が、Chrome 自体にキャレットブラウズモードがないので、
   こうする以外にキャレットを使う方法が見当たりません……
2. `document.body.spellcheck` を `false` にしている理由
   ドキュメント全体を編集可能にした時点で、ドキュメント全体にスペルチェックが走ってしまい、
   赤線が表示されてしまうためです。
   それを回避するために、いったん `false` にして
   キャレットモード終了時に元の状態に戻しています。
